### PR TITLE
Fix DB init in AsyncVideo

### DIFF
--- a/src/object_detector/video/async_video.py
+++ b/src/object_detector/video/async_video.py
@@ -80,15 +80,6 @@ class AsyncVideo:
         # ── buffers
         self._buf_in = Queue(maxsize=2)
 
-        # ── DB setup
-        try:
-            self.db = CountDatabase(str(Config.DB_PATH))
-        except Exception as e:
-            self.db = None
-            logger.warning("CountDatabase init failed: %s", e)
-        self._save_interval = Config.COUNT_SAVE_INTERVAL_SEC
-        self.camera_id      = id(self)
-
         # ── DB setup: gunakan parameter, fallback ke Config
         self.db_path = db_path or str(Config.DB_PATH)
         self.host_id = host_id or Config.HOST_ID


### PR DESCRIPTION
## Summary
- remove first CountDatabase init in AsyncVideo
- rely on parameter-based initialization only

## Testing
- `pytest -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68527670477883308cca246302b73c6f