### PR TITLE
Switch debug print to logger

### DIFF
--- a/src/object_detector/__init__.py
+++ b/src/object_detector/__init__.py
@@ -1,0 +1,7 @@
+"""Package initialization for object_detector."""
+
+import logging
+from .config import Config
+
+# Configure root logging once using configurable level.
+logging.basicConfig(level=Config.get_log_level())

--- a/src/object_detector/async_video.py
+++ b/src/object_detector/async_video.py
@@ -329,7 +329,11 @@ class AsyncVideo:
                     cls_id = self.track_classes.get(tid)
                     if cls_id is not None and cls_id in self.counts:
                         self.counts[cls_id] += 1
-                        print(f"[DEBUG] Counted {self.names[cls_id]}! Total {self.counts[cls_id]}")
+                        logger.debug(
+                            "Counted %s! Total %d",
+                            self.names[cls_id],
+                            self.counts[cls_id],
+                        )
                         # 🚀 Kirim count ke GUI langsung di sini:
                         if self.on_count:
                             snapshot = {i: c for i, c in self.counts.items() if c > 0}

--- a/src/object_detector/config.py
+++ b/src/object_detector/config.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import Tuple, List, Dict
 from zoneinfo import ZoneInfo
 import openvino as ov
+import os
+import logging
 
 
 class Config:
@@ -26,6 +28,14 @@ class Config:
     # host identifier default
     HOST_ID: str = "default-host"
     TIMEZONE: ZoneInfo = ZoneInfo("Asia/Jakarta")
+
+    # logging
+    LOG_LEVEL: str = os.getenv("LIMA_LOG_LEVEL", "WARNING").upper()
+
+    @classmethod
+    def get_log_level(cls) -> int:
+        """Return logging level as int for logging.basicConfig."""
+        return getattr(logging, cls.LOG_LEVEL, logging.WARNING)
 
     # OpenVINO devices - replaced ONNX providers
     OPENVINO_DEVICES: List[str] = ["GPU", "CPU", "AUTO"]

--- a/src/object_detector/gui/main_window.py
+++ b/src/object_detector/gui/main_window.py
@@ -34,7 +34,7 @@ from .widgets.database_settings_panel  import DatabaseSettingsPanel
 from .widgets.menu_panel               import setup_menubar
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.WARNING)
+logging.basicConfig(level=Config.get_log_level())
 
 @contextmanager
 def block_signals(widgets: List[QWidget]):


### PR DESCRIPTION
## Summary
- move logging config to package init with env var support
- allow GUI to use configured log level
- log track counting debug messages with `logger.debug`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6852771605d083309c72131d24ff1868