### PR TITLE
Improve pipeline stop handling

### DIFF
--- a/src/object_detector/video/async_video.py
+++ b/src/object_detector/video/async_video.py
@@ -386,6 +386,17 @@ class AsyncVideo:
 
     # ───────────────────── teardown ──────────────────────────────────
     def stop(self):
-        self._stop_requested.set(); self._running.clear()
+        self._stop_requested.set()
+        self._running.clear()
+
+        # Flush any remaining counts before shutting down workers
+        if self._save_enabled.is_set():
+            try:
+                self._flush_counts_once()
+            except Exception as e:  # pragma: no cover - log only
+                logger.warning("Final count flush failed: %s", e)
+
         self.cap.release()
-        self._capture_thread.join(); self._inference_thread.join(); self._save_thread.join()
+        self._capture_thread.join()
+        self._inference_thread.join()
+        self._save_thread.join()

--- a/tests/utils/test_async_video_stop.py
+++ b/tests/utils/test_async_video_stop.py
@@ -1,0 +1,38 @@
+from threading import Event
+from object_detector.video.async_video import AsyncVideo
+
+class DummyThread:
+    def __init__(self):
+        self.join_called = False
+    def join(self):
+        self.join_called = True
+
+class DummyCap:
+    def __init__(self):
+        self.released = False
+    def release(self):
+        self.released = True
+
+
+def test_stop_flushes_counts_and_joins_threads():
+    av = object.__new__(AsyncVideo)
+    av._stop_requested = Event()
+    av._running = Event(); av._running.set()
+    av._save_enabled = Event(); av._save_enabled.set()
+    av.cap = DummyCap()
+    av._capture_thread = DummyThread()
+    av._inference_thread = DummyThread()
+    av._save_thread = DummyThread()
+
+    called = {}
+    def fake_flush(self, *a, **kw):
+        called['ok'] = True
+    av._flush_counts_once = fake_flush.__get__(av, AsyncVideo)
+
+    AsyncVideo.stop(av)
+
+    assert called.get('ok') is True
+    assert av.cap.released
+    assert av._capture_thread.join_called
+    assert av._inference_thread.join_called
+    assert av._save_thread.join_called


### PR DESCRIPTION
## Summary
- flush outstanding counts when AsyncVideo stops to avoid data loss
- add regression test for stop logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685278e653f08330b50ab03a7b07297c